### PR TITLE
pkgs_pip.txt에 opencv-contrib-python 패키지 추가

### DIFF
--- a/rpython/pkgs_pip.txt
+++ b/rpython/pkgs_pip.txt
@@ -6,6 +6,7 @@ fredapi
 hangulize
 ipython-sql
 konlpy
+opencv-contrib-python
 picklable_itertools
 q
 wbdata


### PR DESCRIPTION
- pkgs_pip.txt에 opencv-contrib-python 패키지 추가